### PR TITLE
Negative duration shifts on schedule

### DIFF
--- a/src/views/Schedule.vue
+++ b/src/views/Schedule.vue
@@ -406,13 +406,7 @@ export default class Schedule extends Vue {
     this.dragEndTime = endTime
 
     if (this.creatingEventDrag) {
-      // Ensure end time is at least 15 minutes after start
-      if (endTime.getTime() - this.virtualEvent.start.getTime() < 15 * 60 * 1000) {
-        this.virtualEvent.end = new Date(this.virtualEvent.start.getTime() + 15 * 60 * 1000)
-      }
-      else {
-        this.virtualEvent.end = endTime
-      }
+      this.virtualEvent.end = endTime
       return
     }
 


### PR DESCRIPTION
Shifts can no longer be resized to negative duration, and there are now loading indicators when a shift is being saved.